### PR TITLE
Override the default createGenerator(File f, JsonEncoding enc)

### DIFF
--- a/src/main/java/com/fasterxml/jackson/dataformat/csv/CsvFactory.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/csv/CsvFactory.java
@@ -396,6 +396,14 @@ public class CsvFactory extends JsonFactory
         return _createGenerator(out, ctxt);
     }
 
+    @Override
+    public CsvGenerator createGenerator(File f, JsonEncoding enc) throws IOException
+    {
+        OutputStream out = new FileOutputStream(f);
+        return createGenerator(out, enc);
+    }
+
+
     /*
     /**********************************************************
     /* Overridden generator factory methods, deprecated

--- a/src/test/java/com/fasterxml/jackson/dataformat/csv/TestGenerator.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/csv/TestGenerator.java
@@ -5,7 +5,10 @@ import com.fasterxml.jackson.core.JsonGenerationException;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.dataformat.csv.ModuleTestBase.FiveMinuteUser.Gender;
+
+import java.io.File;
 
 public class TestGenerator extends ModuleTestBase
 {
@@ -164,6 +167,26 @@ public class TestGenerator extends ModuleTestBase
         String expOutput = "id,\""+expOutputDesc+"\"";
         String result = mapper.writer(schema).writeValueAsString(new IdDesc("id", inputDesc)).trim();
         assertEquals(expOutput, result);
+    }
+
+    public void testWriteInFile() throws Exception
+    {
+        ObjectMapper mapper = mapperForCsv();
+        CsvSchema schema = CsvSchema.builder()
+                .addColumn("firstName")
+                .addColumn("lastName")
+                .build();
+
+        ObjectNode node = mapper.createObjectNode()
+                .put("firstName", "David")
+                .put("lastName", "Douillet");
+
+        File file = File.createTempFile("file", ".csv");
+        try {
+            mapper.writer(schema.withHeader()).writeValue(file, node);
+        } finally {
+            file.delete();
+        }
     }
     
     /*


### PR DESCRIPTION
When we use writeValue(File file, Object value) to write a CSV, we have got this exception : 
Generator of type com.fasterxml.jackson.core.json.UTF8JsonGenerator does not support schema of type 'CSV'

I found that writeValue(File file, Object value) call the default createGenerator(File f, JsonEncoding enc) that always return an UTF8JsonGenerator. So, I overrode to get a CsvGenerator.

I hope that will also be useful for others.
