### PR TITLE
Missing object reference in write example

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ The most common method for reading CSV data, then, is:
 CsvMapper mapper = new CsvMapper();
 Pojo value = ...;
 CsvSchema schema = mapper.schemaFor(Pojo.class); // schema from 'Pojo' definition
-String csv = mapper.writer(schema).writeValueAsString();
+String csv = mapper.writer(schema).writeValueAsString(value);
 Pojo result = mapper.reader(Pojo.class).with(schema).read(csv);
 ```
 


### PR DESCRIPTION
This patch fixes write to CSV example - it was calling writeValueAsString without passing in object to be written.
