### PR TITLE
Support escapes at beginning of the file

### DIFF
--- a/src/main/java/com/fasterxml/jackson/dataformat/csv/impl/CsvReader.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/csv/impl/CsvReader.java
@@ -563,9 +563,16 @@ public class CsvReader
             _textBuffer.resetWithString("");
             return "";
         }
+
         char[] outBuf = _textBuffer.emptyAndGetCurrentSegment();
         outBuf[0] = (char) i;
         int outPtr = 1;
+
+        if (i == _escapeChar) {
+            // Reset the escaped character
+            outBuf[0] = _unescape();
+            return _nextUnquotedString(outBuf, outPtr);
+        }
 
         int ptr = _inputPtr;
         if (ptr >= _inputEnd) {

--- a/src/test/java/com/fasterxml/jackson/dataformat/csv/TestParserEscapes.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/csv/TestParserEscapes.java
@@ -47,5 +47,16 @@ public class TestParserEscapes extends ModuleTestBase
         assertEquals("abc\\def", result.id);
         assertEquals("Desc with\nlinefeed", result.desc);
     }
-    
+
+    public void testEscapesAtStartInUnquoted() throws Exception
+    {
+        CsvMapper mapper = mapperForCsv();
+        CsvSchema schema = mapper.schemaFor(Desc.class).withColumnSeparator('|').withEscapeChar('\\');
+        final String id = "\\|abcdef"; // doubled for javac
+        final String desc = "Desc with\\\nlinefeed";
+        String input = id+"|"+desc+"\n";
+        Desc result = mapper.reader(schema).withType(Desc.class).readValue(input);
+        assertEquals("|abcdef", result.id);
+        assertEquals("Desc with\nlinefeed", result.desc);
+    }
 }


### PR DESCRIPTION
@wli600 
CsvReader doesn't properly unescape characters if the escape character is the first character read.
I've added a test and addressed the issue.