### PR TITLE
Changed logic in Parser _readHeaderLine

### DIFF
--- a/src/main/java/com/fasterxml/jackson/dataformat/csv/CsvParser.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/csv/CsvParser.java
@@ -3,7 +3,6 @@ package com.fasterxml.jackson.dataformat.csv;
 import java.io.*;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.ArrayList;
 
 import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.core.base.ParserMinimalBase;
@@ -810,19 +809,22 @@ public class CsvParser
 
             a) The schema has been populated.  In this case, build a new
                schema where the order matches the *actual* order in which
-               the given CSV file offers its columns; there cases the
-               consumer of the csv file knows about the columns but not
-               necessarily the order in which they are defined.
-
-               A further check can be done in this case, by not permitting
-               new columns that are not defined in the schema, by adding
-               a new flag to the schema (say, strict) and reporting an
-               error when a new column is found in the header.
+               the given CSV file offers its columns, iif _schema.reordersColumns()
+               is set to true; there cases the consumer of the csv file
+               knows about the columns but not necessarily the order in
+               which they are defined.
 
             b) The schema has not been populated.  In this case, build a
                default schema based on the columns found in the header.
          */
 
+        if (_schema.size() > 0 && !_schema.reordersColumns()) {
+            //noinspection StatementWithEmptyBody
+            while (_reader.nextString() != null) { /* does nothing */ }
+            return;
+        }
+
+        // either the schema is empty or reorder columns flag is set
         String name;
         CsvSchema.Builder builder = _schema.rebuild().clearColumns();
 

--- a/src/main/java/com/fasterxml/jackson/dataformat/csv/CsvSchema.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/csv/CsvSchema.java
@@ -81,6 +81,7 @@ public class CsvSchema
     protected final static int ENCODING_FEATURE_USE_HEADER = 0x0001;
     protected final static int ENCODING_FEATURE_SKIP_FIRST_DATA_ROW = 0x0002;
     protected final static int ENCODING_FEATURE_ALLOW_COMMENTS = 0x0004;
+    protected final static int ENCODING_FEATURE_REORDER_COLUMNS = 0x0008;
 
     protected final static int DEFAULT_ENCODING_FEATURES = 0;
 
@@ -455,6 +456,19 @@ public class CsvSchema
         }
 
         /**
+         * Use in combination with setUseHeader.  When use header flag is
+         * is set, this setting will reorder the columns defined in this
+         * schema to match the order set by the header.
+         *
+         * @param b         Enable / Disable this setting
+         * @return          This Builder instance
+         */
+        public Builder setReorderColumns(boolean b) {
+            _feature(ENCODING_FEATURE_REORDER_COLUMNS, b);
+            return this;
+        }
+
+        /**
          * Method for specifying whether Schema should indicate that
          * the first line that is not a header (if header handling enabled)
          * should be skipped in its entirety.
@@ -775,6 +789,18 @@ public class CsvSchema
     }
 
     /**
+     * Returns a clone of this instance by changing or setting the
+     * column reordering flag
+     *
+     * @param state     New value for setting
+     * @return          A copy of itself, ensuring the setting for
+     *                  the column reordering feature.
+     */
+    public CsvSchema withColumnReordering(boolean state) {
+        return _withFeature(ENCODING_FEATURE_REORDER_COLUMNS, state);
+    }
+
+    /**
      * Helper method for constructing and returning schema instance that
      * is similar to this one, except that it will be using header line.
      */
@@ -968,6 +994,7 @@ public class CsvSchema
      */
 
     public boolean usesHeader() { return (_features & ENCODING_FEATURE_USE_HEADER) != 0; }
+    public boolean reordersColumns() { return (_features & ENCODING_FEATURE_REORDER_COLUMNS) != 0; }
     public boolean skipsFirstDataRow() { return (_features & ENCODING_FEATURE_SKIP_FIRST_DATA_ROW) != 0; }
     public boolean allowsComments() { return (_features & ENCODING_FEATURE_ALLOW_COMMENTS) != 0; }
 

--- a/src/test/java/com/fasterxml/jackson/dataformat/csv/schema/SchemaTest.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/csv/schema/SchemaTest.java
@@ -142,5 +142,20 @@ public class SchemaTest extends ModuleTestBase
 
         assertEquals(schema1.size(), schema2.size());
         assertEquals(schema1.column(0).getName(), schema2.column(0).getName());
-    }    
+    }
+
+    // For pull request 89
+    public void testSchemaWithReordering()
+    {
+        // Checks flags are handled properly through builder, getters
+        // and with* functions
+        CsvSchema schemaWithReordering = CsvSchema.builder()
+                .setUseHeader(true)
+                .setReorderColumns(true)
+                .build();
+
+        assertTrue(schemaWithReordering.reordersColumns());
+        CsvSchema schemaWithoutReordering = schemaWithReordering.withColumnReordering(false);
+        assertFalse(schemaWithoutReordering.reordersColumns());
+    }
 }


### PR DESCRIPTION
Hi,

I would like to propose a sightly different way to process headers during parsing.  In some cases, the CSV file consumer does know the columns a file may contain, but not necessarily in the exact order.  

In this scenario, the consumer sets the schema but it also ask to process the header, in such way that actual order of the columns in the schema is determined by the header itself.

This patch tweaks sightly the method _readHeaderLine() in such way that the header is always processed, ensuring the proper order of the columns in the schema.  Previously, if a schema was defined, the header line was skipped altogether.

If no schema is provided, a default schema is built (as it did previously).  

All existing tests run correctly after this change.

Thanks,

Justo.
