### PR TITLE
Verify CSV headers are in the order as expected

### DIFF
--- a/src/main/java/com/fasterxml/jackson/dataformat/csv/CsvParser.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/csv/CsvParser.java
@@ -838,8 +838,24 @@ public class CsvParser
          */
 
         if (_schema.size() > 0 && !_schema.reordersColumns()) {
-            //noinspection StatementWithEmptyBody
-            while (_reader.nextString() != null) { /* does nothing */ }
+            if (_schema.strictHeaders()) {
+                String name;
+                for (CsvSchema.Column column : _schema._columns) {
+                    name = _reader.nextString();
+                    if (name == null) {
+                        _reportError(String.format("Missing header %s", column.getName()));
+                    } else if (!column.getName().equals(name)) {
+                        _reportError(String.format("Expected header %s, actual header %s", column.getName(), name));
+                    }
+                }
+                if ((name = _reader.nextString()) != null) {
+                    _reportError(String.format("Extra header %s", name));
+                }
+            }
+            else {
+                //noinspection StatementWithEmptyBody
+                while (_reader.nextString() != null) { /* does nothing */ }
+            }
             return;
         }
 

--- a/src/main/java/com/fasterxml/jackson/dataformat/csv/CsvSchema.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/csv/CsvSchema.java
@@ -83,6 +83,7 @@ public class CsvSchema
     protected final static int ENCODING_FEATURE_SKIP_FIRST_DATA_ROW = 0x0002;
     protected final static int ENCODING_FEATURE_ALLOW_COMMENTS = 0x0004;
     protected final static int ENCODING_FEATURE_REORDER_COLUMNS = 0x0008;
+    protected final static int ENCODING_FEATURE_STRICT_HEADERS = 0x0016;
 
     protected final static int DEFAULT_ENCODING_FEATURES = 0;
 
@@ -471,6 +472,22 @@ public class CsvSchema
             return this;
         }
 
+
+        /**
+         * Use in combination with setUseHeader.  When use header flag is
+         * is set, this setting will ensure the headers are in the order
+         * of the schema
+         *
+         * @param b         Enable / Disable this setting
+         * @return          This Builder instance
+         *
+         * @since 2.7
+         */
+        public Builder setStrictHeaders(boolean b) {
+            _feature(ENCODING_FEATURE_STRICT_HEADERS, b);
+            return this;
+        }
+
         /**
          * Method for specifying whether Schema should indicate that
          * the first line that is not a header (if header handling enabled)
@@ -805,6 +822,19 @@ public class CsvSchema
     }
 
     /**
+     * Returns a clone of this instance by changing or setting the
+     * strict headers flag
+     *
+     * @param state     New value for setting
+     * @return          A copy of itself, ensuring the setting for
+     *                  the strict headers feature.
+     * @since 2.7
+     */
+    public CsvSchema withStrictColumns(boolean state) {
+        return _withFeature(ENCODING_FEATURE_STRICT_HEADERS, state);
+    }
+
+    /**
      * Helper method for constructing and returning schema instance that
      * is similar to this one, except that it will be using header line.
      */
@@ -1001,6 +1031,7 @@ public class CsvSchema
     public boolean reordersColumns() { return (_features & ENCODING_FEATURE_REORDER_COLUMNS) != 0; }
     public boolean skipsFirstDataRow() { return (_features & ENCODING_FEATURE_SKIP_FIRST_DATA_ROW) != 0; }
     public boolean allowsComments() { return (_features & ENCODING_FEATURE_ALLOW_COMMENTS) != 0; }
+    public boolean strictHeaders() { return (_features & ENCODING_FEATURE_STRICT_HEADERS) != 0; }
 
     /**
      * @deprecated Use {@link #usesHeader()} instead


### PR DESCRIPTION
While I enjoy the flexibility of having the columns in any order, I happen to have the requirement that I need columns in a specific order, and if the headers don't arrive in that order, I want to fail fast. This pull request allows users to enable a feature `strictHeaders` 

Just wanted to present my idea. I'm more than happy to work with you if you want the feature and have suggestions for it. Alternatively, if there is an easy workaround, I'd love to hear about it.