### PR TITLE
trim spaces: don't trim/strip separator character

### DIFF
--- a/src/main/java/com/fasterxml/jackson/dataformat/csv/impl/CsvDecoder.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/csv/impl/CsvDecoder.java
@@ -925,7 +925,7 @@ public class CsvDecoder
                 }
             }
             char ch = _inputBuffer[_inputPtr++];
-            if (ch > ' ') {
+            if (ch > ' ' || ch == _separatorChar) {
                 return ch;
             }
             switch (ch) {

--- a/src/test/java/com/fasterxml/jackson/dataformat/csv/deser/ParserTrimSpacesTest.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/csv/deser/ParserTrimSpacesTest.java
@@ -92,4 +92,37 @@ public class ParserTrimSpacesTest extends ModuleTestBase
         assertFalse(it.hasNext());
         it.close();
     }
+
+    public void testTrimmingTabSeparated() throws Exception
+    {
+        CsvMapper mapper = mapperForCsv();
+        mapper.enable(CsvParser.Feature.TRIM_SPACES);
+        CsvSchema schema = mapper.schemaFor(Entry.class).withColumnSeparator('\t');
+        MappingIterator<Entry> it = mapper.readerFor(Entry.class).with(schema).
+        readValues(
+            "a\t\t  c\n 1\t2\t\" 3\" \n\"ab\" \t\"c  \t\"\t  \n"
+        );
+        Entry entry;
+
+        assertTrue(it.hasNext());
+        assertNotNull(entry = it.nextValue());
+        assertEquals("a", entry.a);
+        assertEquals("", entry.b);
+        assertEquals("c", entry.c);
+
+        assertTrue(it.hasNext());
+        assertNotNull(entry = it.nextValue());
+        assertEquals("1", entry.a);
+        assertEquals("2", entry.b);
+        assertEquals(" 3", entry.c); // note: space within quotes is preserved
+
+        assertTrue(it.hasNext());
+        assertNotNull(entry = it.nextValue());
+        assertEquals("ab", entry.a);
+        assertEquals("c  \t", entry.b);
+        assertEquals("", entry.c);
+
+        assertFalse(it.hasNext());
+        it.close();
+    }
 }


### PR DESCRIPTION
If tab is used as the separator character, the TRIM_SPACES feature will "eat" an empty column.

For example: `a\tb\t\td` will end up with `d` in the third column instead of the fourth.  A trivial fix corrects this.

Also included a unit test.