### PR TITLE
Update Readme : reader -> readerFor + Map<String,String> schema example

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ CsvSchema schema = CsvSchema.builder()
 // NOTE: reads schema and uses it for binding
 CsvSchema bootstrapSchema = CsvSchema.emptySchema().withHeader();
 ObjectMapper mapper = new CsvMapper();
-mapper.reader(Pojo.class).with(bootstrapSchema).readValue(json);
+mapper.readerFor(Pojo.class).with(bootstrapSchema).readValue(json);
 ```
 
 It is important to note that the schema object is needed to ensure correct ordering of columns; schema instances are immutable and fully reusable (as are `ObjectWriter` instances).
@@ -81,7 +81,7 @@ CsvMapper mapper = new CsvMapper();
 Pojo value = ...;
 CsvSchema schema = mapper.schemaFor(Pojo.class); // schema from 'Pojo' definition
 String csv = mapper.writer(schema).writeValueAsString(value);
-Pojo result = mapper.reader(Pojo.class).with(schema).read(csv);
+Pojo result = mapper.readerFor(Pojo.class).with(schema).read(csv);
 ```
 
 ## Data-binding without schema
@@ -112,7 +112,7 @@ CsvMapper mapper = new CsvMapper();
 // important: we need "array wrapping" (see next section) here:
 mapper.enable(CsvParser.Feature.WRAP_AS_ARRAY);
 File csvFile = new File("input.csv"); // or from String, URL etc
-MappingIterator<String[]> it = mapper.reader(String[].class).readValues(csvFile);
+MappingIterator<String[]> it = mapper.readerFor(String[].class).readValues(csvFile);
 while (it.hasNext()) {
   String[] row = it.next();
   // and voila, column values in an array. Works with Lists as well
@@ -135,7 +135,7 @@ we could use following code:
 
 ```java
 CsvSchema schema = CsvSchema.emptySchema().withHeader(); // use first row as header; otherwise defaults are fine
-MappingIterator<Map<String,String>> it = mapper.reader(Map.class)
+MappingIterator<Map<String,String>> it = mapper.readerFor(Map.class)
    .with(schema)
    .readValues(csvFile);
 while (it.hasNext()) {

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Barbara,36
 we could use following code:
 
 ```java
+CsvMapper mapper = new CsvMapper();
 CsvSchema schema = CsvSchema.emptySchema().withHeader(); // use first row as header; otherwise defaults are fine
 MappingIterator<Map<String,String>> it = mapper.readerFor(Map.class)
    .with(schema)
@@ -152,6 +153,19 @@ and get two rows as `java.util.Map`s, similar to what JSON like this
 ```
 
 would produce.
+
+Additionally, to generate a schema for the `Map<String,String>`,
+we could do the following :
+
+```java
+CsvSchema.Builder schema = new CsvSchema.Builder();
+for (String value : map.keySet())
+{
+    schema.addColumn(value, CsvSchema.ColumnType.STRING);
+}
+new CsvMapper().writerFor(Map.class).with(schema.build());
+```
+
 
 ## Adding virtual Array wrapping
 


### PR DESCRIPTION
Updated readme with the following: 

Changed the deprecated method reader(Pojo.class) to readerFor(Pojo.class).

Added example of how to create a schema for the Map<String, String> class mentioned in the documentation.