### PR TITLE
Fix strict header flag to correct hexadecimal number

### DIFF
--- a/src/main/java/com/fasterxml/jackson/dataformat/csv/CsvSchema.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/csv/CsvSchema.java
@@ -91,7 +91,7 @@ public class CsvSchema
     protected final static int ENCODING_FEATURE_SKIP_FIRST_DATA_ROW = 0x0002;
     protected final static int ENCODING_FEATURE_ALLOW_COMMENTS = 0x0004;
     protected final static int ENCODING_FEATURE_REORDER_COLUMNS = 0x0008;
-    protected final static int ENCODING_FEATURE_STRICT_HEADERS = 0x0016;
+    protected final static int ENCODING_FEATURE_STRICT_HEADERS = 0x0010;
 
     protected final static int DEFAULT_ENCODING_FEATURES = 0;
 

--- a/src/test/java/com/fasterxml/jackson/dataformat/csv/deser/BasicParserTest.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/csv/deser/BasicParserTest.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.dataformat.csv.*;
+import com.google.common.collect.Lists;
 
 import static org.junit.Assert.assertArrayEquals;
 
@@ -403,5 +404,24 @@ public class BasicParserTest extends ModuleTestBase {
             verifyException(e, "Extra header d");
         }
         parser.close();
+    }
+
+    public void testStrictColumnReturnsExpectedData() throws IOException {
+        CsvSchema schema = MAPPER.schemaFor(Point.class).withHeader().withStrictHeaders(true);
+
+        String CSV = "x,y,z\n1,2,3\n4,5,6\n7,8,9";
+
+        final MappingIterator<Point> iter = MAPPER.readerFor(Point.class).with(schema).readValues(CSV);
+        final ArrayList<Point> values = Lists.newArrayList(iter);
+        assertEquals(3, values.size());
+        assertEquals(1, values.get(0).x);
+        assertEquals(2, values.get(0).y.intValue());
+        assertEquals(3, values.get(0).z.intValue());
+        assertEquals(4, values.get(1).x);
+        assertEquals(5, values.get(1).y.intValue());
+        assertEquals(6, values.get(1).z.intValue());
+        assertEquals(7, values.get(2).x);
+        assertEquals(8, values.get(2).y.intValue());
+        assertEquals(9, values.get(2).z.intValue());
     }
 }


### PR DESCRIPTION
Previously `ENCODING_FEATURE_STRICT_HEADERS` was the hexadecimal flag of `0x0016` when it should be `0x0010`. My apologies for a bug fix so late in the release cycle