### PR TITLE
Option to force quoting of empty strings

### DIFF
--- a/src/main/java/com/fasterxml/jackson/dataformat/csv/CsvGenerator.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/csv/CsvGenerator.java
@@ -64,6 +64,12 @@ public class CsvGenerator extends GeneratorBase
          * @since 2.5
          */
         ALWAYS_QUOTE_STRINGS(false),
+
+        /**
+         * Feature that determines whether values written as empty Strings (from <code>java.lang.String</code>
+         * valued POJO properties) should be forced to be quoted.
+         */
+        ALWAYS_QUOTE_EMPTY_STRINGS(false),
         ;
 
         protected final boolean _defaultState;

--- a/src/main/java/com/fasterxml/jackson/dataformat/csv/impl/CsvEncoder.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/csv/impl/CsvEncoder.java
@@ -88,6 +88,8 @@ public class CsvEncoder
      * @since 2.5
      */
     protected boolean _cfgAlwaysQuoteStrings;
+
+    protected boolean _cfgAlwaysQuoteEmptyStrings;
     
     /*
     /**********************************************************
@@ -166,6 +168,7 @@ public class CsvEncoder
         _cfgOptimalQuoting = CsvGenerator.Feature.STRICT_CHECK_FOR_QUOTING.enabledIn(csvFeatures);
         _cfgIncludeMissingTail = !CsvGenerator.Feature.OMIT_MISSING_TAIL_COLUMNS.enabledIn(_csvFeatures);
         _cfgAlwaysQuoteStrings = CsvGenerator.Feature.ALWAYS_QUOTE_STRINGS.enabledIn(csvFeatures);
+        _cfgAlwaysQuoteEmptyStrings = CsvGenerator.Feature.ALWAYS_QUOTE_EMPTY_STRINGS.enabledIn(csvFeatures);
 
         _outputBuffer = ctxt.allocConcatBuffer();
         _bufferRecyclable = true;
@@ -193,7 +196,8 @@ public class CsvEncoder
         _cfgOptimalQuoting = base._cfgOptimalQuoting;
         _cfgIncludeMissingTail = base._cfgIncludeMissingTail;
         _cfgAlwaysQuoteStrings = base._cfgAlwaysQuoteStrings;
-        
+        _cfgAlwaysQuoteEmptyStrings = base._cfgAlwaysQuoteEmptyStrings;
+
         _outputBuffer = base._outputBuffer;
         _bufferRecyclable = base._bufferRecyclable;
         _outputEnd = base._outputEnd;
@@ -232,6 +236,7 @@ public class CsvEncoder
             _cfgOptimalQuoting = CsvGenerator.Feature.STRICT_CHECK_FOR_QUOTING.enabledIn(feat);
             _cfgIncludeMissingTail = !CsvGenerator.Feature.OMIT_MISSING_TAIL_COLUMNS.enabledIn(feat);
             _cfgAlwaysQuoteStrings = CsvGenerator.Feature.ALWAYS_QUOTE_STRINGS.enabledIn(feat);
+            _cfgAlwaysQuoteEmptyStrings = CsvGenerator.Feature.ALWAYS_QUOTE_EMPTY_STRINGS.enabledIn(feat);
         }
         return this;
     }
@@ -869,6 +874,9 @@ public class CsvEncoder
         }
         if (_cfgEscapeCharacter > 0) {
             return _needsQuotingLoose(value, _cfgEscapeCharacter);
+        }
+        if (_cfgAlwaysQuoteEmptyStrings && length == 0) {
+            return true;
         }
         return _needsQuotingLoose(value);
     }

--- a/src/test/java/com/fasterxml/jackson/dataformat/csv/ser/TestGenerator.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/csv/ser/TestGenerator.java
@@ -190,18 +190,37 @@ public class TestGenerator extends ModuleTestBase
         CsvMapper mapper = mapperForCsv();
         mapper.enable(CsvGenerator.Feature.ALWAYS_QUOTE_STRINGS);
         CsvSchema schema = CsvSchema.builder()
-            .addColumn("id")
-            .addColumn("amount")
-            .build();
+                                    .addColumn("id")
+                                    .addColumn("amount")
+                                    .build();
         String result = mapper.writer(schema)
-                .writeValueAsString(new Entry("abc", 1.25));
+                              .writeValueAsString(new Entry("abc", 1.25));
         assertEquals("\"abc\",1.25\n", result);
 
         // Also, as per [dataformat-csv#81], should be possible to change dynamically
         result = mapper.writer(schema)
-                .without(CsvGenerator.Feature.ALWAYS_QUOTE_STRINGS)
-                .writeValueAsString(new Entry("xyz", 2.5));
+                       .without(CsvGenerator.Feature.ALWAYS_QUOTE_STRINGS)
+                       .writeValueAsString(new Entry("xyz", 2.5));
         assertEquals("xyz,2.5\n", result);
+    }
+
+    public void testForcedQuotingEmptyStrings() throws Exception
+    {
+        CsvMapper mapper = mapperForCsv();
+        mapper.enable(CsvGenerator.Feature.ALWAYS_QUOTE_EMPTY_STRINGS);
+        CsvSchema schema = CsvSchema.builder()
+                                    .addColumn("id")
+                                    .addColumn("amount")
+                                    .build();
+        String result = mapper.writer(schema)
+                              .writeValueAsString(new Entry("", 1.25));
+        assertEquals("\"\",1.25\n", result);
+
+        // Also, as per [dataformat-csv#81], should be possible to change dynamically
+        result = mapper.writer(schema)
+                       .without(CsvGenerator.Feature.ALWAYS_QUOTE_EMPTY_STRINGS)
+                       .writeValueAsString(new Entry("", 2.5));
+        assertEquals(",2.5\n", result);
     }
 
     // Must comment '#', at least if it starts the line


### PR DESCRIPTION
Similar to CsvGenerator.Feature.ALWAYS_QUOTE_STRINGS, CsvGenerator.Feature.ALWAYS_QUOTE_EMPTY_STRINGS forces quoting of *empty* strings.

This is important for some data warehouses, which use quoting to differentiate between null and empty-string.