### PR TITLE
Fix issue #128 headers are not written if no rows are written

### DIFF
--- a/src/main/java/com/fasterxml/jackson/dataformat/csv/CsvGenerator.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/csv/CsvGenerator.java
@@ -428,6 +428,12 @@ public class CsvGenerator extends GeneratorBase
 
         // Let's mark row as closed, if we had any...
         finishRow();
+        
+        // Write the header if necessary, occurs when no rows written
+        if (_handleFirstLine) {
+            _handleFirstLine();
+        }
+
         _writer.close(_ioContext.isResourceManaged() || isEnabled(JsonGenerator.Feature.AUTO_CLOSE_TARGET));
     }
 

--- a/src/test/java/com/fasterxml/jackson/dataformat/csv/ser/HeaderWriteTest.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/csv/ser/HeaderWriteTest.java
@@ -22,19 +22,19 @@ public class HeaderWriteTest extends ModuleTestBase
     public void testNoLines() throws Exception
     {
         List<String> headers = Arrays.asList("TestHeader1", "TestHeader2");
-    	List<List<String>> dataSource = Arrays.asList();
-		String result = runTest(headers, dataSource);
-		
-		assertEquals("Headers should have been written even with no other data", "TestHeader1,TestHeader2\n", result);
+        List<List<String>> dataSource = Arrays.asList();
+        String result = runTest(headers, dataSource);
+        
+        assertEquals("Headers should have been written even with no other data", "TestHeader1,TestHeader2\n", result);
     }
     
     public void testOneLine() throws Exception
     {
         List<String> headers = Arrays.asList("TestHeader1", "TestHeader2");
-    	List<List<String>> dataSource = Arrays.asList(Arrays.asList("TestValue1", "TestValue2"));
-		String result = runTest(headers, dataSource);
-		
-		assertEquals("Headers should have been written before line", "TestHeader1,TestHeader2\nTestValue1,TestValue2\n", result);
+        List<List<String>> dataSource = Arrays.asList(Arrays.asList("TestValue1", "TestValue2"));
+        String result = runTest(headers, dataSource);
+        
+        assertEquals("Headers should have been written before line", "TestHeader1,TestHeader2\nTestValue1,TestValue2\n", result);
     }
     
     private String runTest(List<String> headers, List<List<String>> dataSource) throws IOException 
@@ -48,14 +48,14 @@ public class HeaderWriteTest extends ModuleTestBase
         
         CsvSchema schema = builder.setUseHeader(true).build();
         try (SequenceWriter csvWriter = MAPPER.writerWithDefaultPrettyPrinter()
-        		                              .with(schema)
-        		                              .forType(List.class)
-        		                              .writeValues(writer);) {
+                                              .with(schema)
+                                              .forType(List.class)
+                                              .writeValues(writer);) {
             for(List<String> nextRow : dataSource) {
-            	csvWriter.write(nextRow);
+                csvWriter.write(nextRow);
             }
         }
         
-		return writer.toString();
+        return writer.toString();
     }
 }

--- a/src/test/java/com/fasterxml/jackson/dataformat/csv/ser/HeaderWriteTest.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/csv/ser/HeaderWriteTest.java
@@ -1,0 +1,61 @@
+package com.fasterxml.jackson.dataformat.csv.ser;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.Arrays;
+import java.util.List;
+
+import com.fasterxml.jackson.databind.SequenceWriter;
+import com.fasterxml.jackson.dataformat.csv.*;
+
+// Tests for verifying that headers are emitted
+public class HeaderWriteTest extends ModuleTestBase
+{
+    /*
+    /**********************************************************************
+    /* Test methods
+    /**********************************************************************
+     */
+
+    private final CsvMapper MAPPER = mapperForCsv();
+    
+    public void testNoLines() throws Exception
+    {
+        List<String> headers = Arrays.asList("TestHeader1", "TestHeader2");
+    	List<List<String>> dataSource = Arrays.asList();
+		String result = runTest(headers, dataSource);
+		
+		assertEquals("Headers should have been written even with no other data", "TestHeader1,TestHeader2\n", result);
+    }
+    
+    public void testOneLine() throws Exception
+    {
+        List<String> headers = Arrays.asList("TestHeader1", "TestHeader2");
+    	List<List<String>> dataSource = Arrays.asList(Arrays.asList("TestValue1", "TestValue2"));
+		String result = runTest(headers, dataSource);
+		
+		assertEquals("Headers should have been written before line", "TestHeader1,TestHeader2\nTestValue1,TestValue2\n", result);
+    }
+    
+    private String runTest(List<String> headers, List<List<String>> dataSource) throws IOException 
+    {
+        StringWriter writer = new StringWriter();
+        
+        CsvSchema.Builder builder = CsvSchema.builder();
+        for (String nextHeader : headers) {
+            builder = builder.addColumn(nextHeader);
+        }
+        
+        CsvSchema schema = builder.setUseHeader(true).build();
+        try (SequenceWriter csvWriter = MAPPER.writerWithDefaultPrettyPrinter()
+        		                              .with(schema)
+        		                              .forType(List.class)
+        		                              .writeValues(writer);) {
+            for(List<String> nextRow : dataSource) {
+            	csvWriter.write(nextRow);
+            }
+        }
+        
+		return writer.toString();
+    }
+}


### PR DESCRIPTION
Fix issue #128 by writing the header during CsvGenerator.close if necessary. See issue comments for discussion so far.