### PR TITLE
issue#130 : Add fluent addColumns operation to CsvSchema.Builder

### DIFF
--- a/src/main/java/com/fasterxml/jackson/dataformat/csv/CsvSchema.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/csv/CsvSchema.java
@@ -466,6 +466,19 @@ public class CsvSchema
             _columns.add(c);
             return this;
         }
+        public Builder addColumns(Iterable<Column> cs) {
+            for (Column c : cs) {
+                _columns.add(c);
+            }
+            return this;
+        }
+        public Builder addColumns(Iterable<String> names, ColumnType type) {
+            Builder result = this;
+            for (String name : names) {
+                result = addColumn(name, type);
+            }
+            return result;
+        }
 
         public Builder addArrayColumn(String name) {
             int index = _columns.size();


### PR DESCRIPTION
Adds two new operations to allow CsvSchema.Builder users to bulk setup a collection of fields using with String+ColumnType or Column and have it integrated with the rest of the fluent interface.

Signed-off-by: Peter Ansell <p_ansell@yahoo.com>